### PR TITLE
TELEMAC-3D: modify how point data are exported for volume sequences

### DIFF
--- a/nimphs/operators/telemac/telemac_generate_volume_sequence.py
+++ b/nimphs/operators/telemac/telemac_generate_volume_sequence.py
@@ -379,7 +379,7 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
 
         # Update list of chosen point data from this operator. Ugly but it works.
         self.point_data.list = context.scene.nimphs.op_vars.dumps()
-        draw_point_data(subbox, self.point_data, show_range=True, edit=True, src='OPERATOR')
+        draw_point_data(subbox, self.point_data, show_remap=False, edit=True, src='OPERATOR')
 
         row = subbox.row()
         row.enabled = context.scene.nimphs.op_vars.length() < self.limit_add_point_data
@@ -549,12 +549,10 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
 
                     # Get variable information
                     variable: PointDataInformation = PointDataManager(self.point_data.list).get(0)
-                    value_range = variable.range.get(self.point_data.remap_method)
                     var_name = variable.name
 
                     # Export volume at current time point
-                    self.volume.export_time_point(self.mesh, [var_name], f"{self.file_name}_{self.file_counter}",
-                                                  remap=value_range)
+                    self.volume.export_time_point(self.mesh, [var_name], f"{self.file_name}_{self.file_counter}")
                     self.file_counter += 1
 
                     # Generate interpolated time steps
@@ -562,7 +560,7 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
                         for interp_time_point in range(1, self.mesh.time_interp_steps + 1):
                             self.mesh.set_time_point(self.time_point, interp_time_point)
                             self.volume.export_time_point(self.mesh, [var_name],
-                                                          f"{self.file_name}_{self.file_counter}", remap=value_range)
+                                                          f"{self.file_name}_{self.file_counter}")
                             self.file_counter += 1
 
                 except BaseException:

--- a/nimphs/operators/telemac/telemac_generate_volume_sequence.py
+++ b/nimphs/operators/telemac/telemac_generate_volume_sequence.py
@@ -298,6 +298,33 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
         # /!\ For testing purpose only /!\ #
         # -------------------------------- #
         if self.mode == 'TEST':
+            # Read test data
+            data = json.loads(self.test_data)
+
+            point_data: PointDataManager = PointDataManager().append(name=data.get("point_data", None))
+            self.point_data = point_data.dumps()
+
+            self.max = data.get("max", 0)
+            self.start = data.get("start", 0)
+            self.end = data.get("end", 0)
+
+            self.output_path = os.path.abspath(data.get("output_path", "/tmp"))
+            self.file_name = data.get("file_name", "DEFAULT_FILE_NAME_VOLUME")
+
+            self.computing_mode = data.get("computing_mode", "DEFAULT")
+            self.nb_threads = data.get("nb_threads", 4)
+
+            self.volume_definition = 'DIMENSIONS'
+            self.dim_x = data.get("dim_x", 0)
+            self.dim_y = data.get("dim_y", 0)
+            self.dim_z = data.get("dim_z", 0)
+
+            self.time_interpolation.type = 'LINEAR'
+            self.time_interpolation.steps = data.get("time_interpolation", 1)
+
+            self.space_interpolation.type = 'LINEAR'
+            self.space_interpolation.steps = data.get("space_interpolation", 1)
+
             return {'FINISHED'}
         else:
             self.file_name = "Volume_sequence"

--- a/nimphs/operators/telemac/telemac_generate_volume_sequence.py
+++ b/nimphs/operators/telemac/telemac_generate_volume_sequence.py
@@ -486,7 +486,7 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
 
         self.cumulated_time = 0.0
         self.file_counter = self.start
-        self.time_point = self.start
+        self.time_point = self.start - 1 if self.mode != 'TEST' else self.start
         # Concatenate output_path and file_name
         self.file_name = os.path.join(os.path.abspath(self.output_path), self.file_name)
 

--- a/nimphs/operators/telemac/telemac_generate_volume_sequence.py
+++ b/nimphs/operators/telemac/telemac_generate_volume_sequence.py
@@ -13,8 +13,8 @@ import numpy as np
 from pathlib import Path
 
 from nimphs.operators.shared.utils import update_end
-from nimphs.operators.shared.modal_operator import NIMPHS_ModalOperator
 from nimphs.panels.utils import get_selected_object, draw_point_data
+from nimphs.operators.shared.modal_operator import NIMPHS_ModalOperator
 from nimphs.operators.shared.create_sequence import NIMPHS_CreateSequence
 from nimphs.checkdeps import HAS_CUDA, HAS_MULTIPROCESSING, HAS_PYOPENVDB
 from nimphs.operators.utils.volume import TelemacMeshForVolume, TelemacVolume
@@ -124,13 +124,14 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
     bl_label = "Volume sequence"
     bl_description = "Generate a volume sequence from a TELEMAC 3D file. Press 'esc' to cancel"
 
-    #: bpy.props.EnumProperty: Computing mode. Enum in ['DEFAULT', 'MULTIPROCESSING', 'CUDA']
+    #: bpy.props.EnumProperty: Computing mode. Enum in ['DEFAULT', 'MULTIPROCESSING', 'CUDA'].
     computing_mode: EnumProperty(
         name="Computing mode",
         description="Select a computing method from a list of available computing modes",
         items=get_available_computing_modes
     )
 
+    #: bpy.props.IntProperty: Number of threads to use when multiprocessing mode is chosen.
     nb_threads: IntProperty(
         name="Number of threads",
         description="Number of threads to use in case the multiprocessing computing method is chosen",
@@ -140,6 +141,7 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
         update=update_nb_threads
     )
 
+    #: bpy.props.StringProperty: Output path for generated .vdb files.
     output_path: StringProperty(
         name="Output path",
         description="Path where to save generated .vdb files",
@@ -147,6 +149,7 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
         subtype="DIR_PATH"      # noqa: F821
     )
 
+    #: bpy.props.StringProperty: File name of generated .vdb files.
     file_name: StringProperty(
         name="Output path",
         description="Name of the files to generate",
@@ -154,6 +157,7 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
         subtype="FILE_NAME"     # noqa: F821
     )
 
+    #: bpy.props.EnumProperty: Indicate how the volume is defined.
     volume_definition: EnumProperty(
         name="Volume definition",
         description="Define the volume dimensions either by providing dimensions or a voxel size",
@@ -163,6 +167,7 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
         ]
     )
 
+    #: bpy.props.IntProperty: Volume dimension along the 'X' axis.
     dim_x: IntProperty(
         name="X dimension",
         default=0,
@@ -171,6 +176,7 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
         update=update_dim_x
     )
 
+    #: bpy.props.IntProperty: Volume dimension along the 'Y' axis.
     dim_y: IntProperty(
         name="Y dimension",
         default=0,
@@ -179,6 +185,7 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
         update=update_dim_y
     )
 
+    #: bpy.props.IntProperty: Volume dimension along the 'Z' axis.
     dim_z: IntProperty(
         name="Z dimension",
         default=0,
@@ -186,6 +193,7 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
         soft_min=1,
     )
 
+    #: bpy.props.IntProperty: Voxel size.
     vx_size: FloatProperty(
         name="Voxel size",
         description="Size of a voxel",
@@ -206,8 +214,10 @@ class NIMPHS_OT_TelemacGenerateVolumeSequence(NIMPHS_CreateSequence, NIMPHS_Moda
         min=0
     )
 
+    #: NIMPHS_TelemacInterpolateProperty: Time interpolation settings.
     time_interpolation: PointerProperty(type=NIMPHS_TelemacInterpolateProperty)
 
+    #: NIMPHS_TelemacInterpolateProperty: Space interpolation settings.
     space_interpolation: PointerProperty(type=NIMPHS_TelemacInterpolateProperty)
 
     #: int: Currently processed time point

--- a/scripts/generate_volume_telemac3d.py
+++ b/scripts/generate_volume_telemac3d.py
@@ -23,8 +23,6 @@ Copyright (C) 2022 ARTELIAGROUP
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath("."))
-sys.path.insert(0, os.path.abspath("../"))
 
 import time
 import numpy as np
@@ -33,9 +31,13 @@ import itertools as it
 from numba import cuda
 import pyopenvdb as vdb
 from copy import deepcopy
-from nimphs.properties.telemac.serafin import Serafin
-from nimphs.operators.utils.others import remap_array
 from multiprocessing import Process, Manager, RawArray
+
+# Custom imports
+sys.path.insert(0, os.path.abspath("../nimphs/operators/utils/"))
+sys.path.insert(0, os.path.abspath("../nimphs/properties/telemac/"))
+from others import remap_array
+from serafin import Serafin
 
 
 class Mesh():

--- a/scripts/load_pytest.py
+++ b/scripts/load_pytest.py
@@ -96,6 +96,10 @@ class SetupPlugin:
         exclude = [os.path.abspath("./cache"), os.path.abspath("./data/openfoam")]
         remove_files_matching_pattern(self.root, exclude_folders=exclude, pattern="*.zip")
 
+        # Cleanup generated vdb files
+        print("Cleaning up - vdb files")
+        remove_files_matching_pattern(os.path.abspath("./cache"), pattern="*.vdb")
+
         # Cleanup testing data
         print("Cleaning up - testing data")
         remove_folders_matching_pattern(os.path.abspath("./data"), pattern="sample")

--- a/scripts/standalone/generate_volume_telemac3d.py
+++ b/scripts/standalone/generate_volume_telemac3d.py
@@ -34,7 +34,7 @@ from copy import deepcopy
 from multiprocessing import Process, Manager, RawArray
 
 # Custom imports
-sys.path.insert(0, os.path.abspath("../nimphs/properties/telemac/"))
+sys.path.insert(0, os.path.abspath("../../nimphs/properties/telemac/"))
 from serafin import Serafin
 
 
@@ -689,7 +689,7 @@ if __name__ == '__main__':
     start_global = time.time()
 
     # ELEVATION Z: 0.0, 4.773
-    mesh = Mesh("../data/telemac_3d/telemac_3d.slf", plane_interp_steps=PLANE_INTERP_STEPS)
+    mesh = Mesh("../../data/telemac_3d/telemac_3d.slf", plane_interp_steps=PLANE_INTERP_STEPS)
 
     NB_TIME_POINTS = mesh.file.nb_pdt
     # NB_TIME_POINTS = 10

--- a/tests/test_generate_volume_sequence.py
+++ b/tests/test_generate_volume_sequence.py
@@ -4,6 +4,7 @@ import sys
 import bpy
 import json
 import pytest
+import warnings
 
 # Make helpers module available in this file
 sys.path.append(os.path.abspath("."))
@@ -25,33 +26,90 @@ def test_generate_volume_sequence_openfoam():
 #         TELEMAC 3D         #
 # -------------------------- #
 
-
-@pytest.mark.usefixtures("clean_all_objects")
-def test_generate_volume_sequence_telemac_3d_multiprocessing():
+def test_generate_volume_sequence_telemac_3d_default():
     # Import TELEMAC 3D sample object
     op = bpy.ops.nimphs.import_telemac_file
     assert op('EXEC_DEFAULT', filepath=utils.FILE_PATH_TELEMAC_3D, name=utils.PRW_OBJ_NAME) == {'FINISHED'}
 
     # Select preview object
-    obj = utils.get_preview_object()
+    utils.get_preview_object()
     sample = utils.get_sample_data(utils.SAMPLE_TELEMAC_3D)
 
     # Set test data:
     data = json.dumps({
         "point_data": sample["point_data"]["names"][0],
         "start": 0,
-        "end": sample["nb_times_points"] - 1,
+        "end": (sample["nb_time_points"] - 1) // 2,
         "max": sample["nb_time_points"] - 1,
-        "computing_mode": "MULTIPROCESSING",
-        "nb_threads": 4,
-        "output_path": os.path.abspath("."),
-        "file_name": "test_volume_telemac_3d",
-        "dim_x": 100,
-        "dim_y": 100,
-        "dim_z": 40,
-        "time_interpolation": 2,
-        "space_interpolation": 5,
+        "computing_mode": "DEFAULT",
+        "nb_threads": 0,
+        "output_path": os.path.abspath("./cache"),
+        "file_name": "test_volume_telemac_3d_default",
+        "dim_x": 50,
+        "dim_y": 50,
+        "dim_z": 50,
+        "time_interpolation": 1,
+        "space_interpolation": 3,
     })
 
+    # TODO: when pyopenvdb installation is fixed, change 'CANCELLED' to 'FINISH' to run the test
     op = bpy.ops.nimphs.telemac_generate_volume_sequence
-    assert op('EXEC_DEFAULT', mode='TEST', test_data=data) == {'FINISHED'}
+    assert op('EXEC_DEFAULT', mode='TEST', test_data=data) == {'CANCELLED'}
+    warnings.warn(UserWarning(f"Test is not fully implemented yet"))
+
+
+def test_generate_volume_sequence_telemac_3d_multiprocessing():
+    # Select preview object
+    utils.get_preview_object()
+    sample = utils.get_sample_data(utils.SAMPLE_TELEMAC_3D)
+
+    # Set test data:
+    data = json.dumps({
+        "point_data": sample["point_data"]["names"][0],
+        "start": 0,
+        "end": (sample["nb_time_points"] - 1) // 2,
+        "max": sample["nb_time_points"] - 1,
+        "computing_mode": "MULTIPROCESSING",
+        "nb_threads": len(os.sched_getaffinity(0)),  # Number of available threads
+        "output_path": os.path.abspath("./cache"),
+        "file_name": "test_volume_telemac_3d_multiprocessing",
+        "dim_x": 50,
+        "dim_y": 50,
+        "dim_z": 50,
+        "time_interpolation": 1,
+        "space_interpolation": 3,
+    })
+
+    # TODO: when pyopenvdb installation is fixed, change 'CANCELLED' to 'FINISH' to run the test
+    op = bpy.ops.nimphs.telemac_generate_volume_sequence
+    assert op('EXEC_DEFAULT', mode='TEST', test_data=data) == {'CANCELLED'}
+    warnings.warn(UserWarning(f"Test is not fully implemented yet"))
+
+
+@pytest.mark.usefixtures("clean_all_objects")
+def test_generate_volume_sequence_telemac_3d_cuda():
+    # Select preview object
+    utils.get_preview_object()
+    sample = utils.get_sample_data(utils.SAMPLE_TELEMAC_3D)
+
+    # Set test data:
+    data = json.dumps({
+        "point_data": sample["point_data"]["names"][0],
+        "start": 0,
+        "end": (sample["nb_time_points"] - 1) // 2,
+        "max": sample["nb_time_points"] - 1,
+        "computing_mode": "CUDA",
+        "nb_threads": 0,  # Number of available threads
+        "output_path": os.path.abspath("./cache"),
+        "file_name": "test_volume_telemac_3d_cuda",
+        "dim_x": 50,
+        "dim_y": 50,
+        "dim_z": 50,
+        "time_interpolation": 1,
+        "space_interpolation": 3,
+    })
+
+    # TODO: when pyopenvdb installation is fixed, change 'CANCELLED' to 'FINISH' to run the test
+    op = bpy.ops.nimphs.telemac_generate_volume_sequence
+    assert op('EXEC_DEFAULT', mode='TEST', test_data=data) == {'CANCELLED'}
+    warnings.warn(UserWarning(f"Test is not fully implemented yet"))

--- a/tests/test_generate_volume_sequence.py
+++ b/tests/test_generate_volume_sequence.py
@@ -1,0 +1,57 @@
+# <pep8 compliant>
+import os
+import sys
+import bpy
+import json
+import pytest
+
+# Make helpers module available in this file
+sys.path.append(os.path.abspath("."))
+from helpers import utils
+# Fixtures
+from helpers.utils import clean_all_objects
+
+
+# ------------------------ #
+#         OpenFOAM         #
+# ------------------------ #
+
+
+def test_generate_volume_sequence_openfoam():
+    pytest.skip(reason="Not implemented yet")
+
+
+# -------------------------- #
+#         TELEMAC 3D         #
+# -------------------------- #
+
+
+@pytest.mark.usefixtures("clean_all_objects")
+def test_generate_volume_sequence_telemac_3d_multiprocessing():
+    # Import TELEMAC 3D sample object
+    op = bpy.ops.nimphs.import_telemac_file
+    assert op('EXEC_DEFAULT', filepath=utils.FILE_PATH_TELEMAC_3D, name=utils.PRW_OBJ_NAME) == {'FINISHED'}
+
+    # Select preview object
+    obj = utils.get_preview_object()
+    sample = utils.get_sample_data(utils.SAMPLE_TELEMAC_3D)
+
+    # Set test data:
+    data = json.dumps({
+        "point_data": sample["point_data"]["names"][0],
+        "start": 0,
+        "end": sample["nb_times_points"] - 1,
+        "max": sample["nb_time_points"] - 1,
+        "computing_mode": "MULTIPROCESSING",
+        "nb_threads": 4,
+        "output_path": os.path.abspath("."),
+        "file_name": "test_volume_telemac_3d",
+        "dim_x": 100,
+        "dim_y": 100,
+        "dim_z": 40,
+        "time_interpolation": 2,
+        "space_interpolation": 5,
+    })
+
+    op = bpy.ops.nimphs.telemac_generate_volume_sequence
+    assert op('EXEC_DEFAULT', mode='TEST', test_data=data) == {'FINISHED'}

--- a/tests/test_generate_volume_sequence.py
+++ b/tests/test_generate_volume_sequence.py
@@ -55,7 +55,7 @@ def test_generate_volume_sequence_telemac_3d_default():
     # TODO: when pyopenvdb installation is fixed, change 'CANCELLED' to 'FINISH' to run the test
     op = bpy.ops.nimphs.telemac_generate_volume_sequence
     assert op('EXEC_DEFAULT', mode='TEST', test_data=data) == {'CANCELLED'}
-    warnings.warn(UserWarning(f"Test is not fully implemented yet"))
+    warnings.warn(UserWarning("Test is not fully implemented yet"))
 
 
 def test_generate_volume_sequence_telemac_3d_multiprocessing():
@@ -83,7 +83,7 @@ def test_generate_volume_sequence_telemac_3d_multiprocessing():
     # TODO: when pyopenvdb installation is fixed, change 'CANCELLED' to 'FINISH' to run the test
     op = bpy.ops.nimphs.telemac_generate_volume_sequence
     assert op('EXEC_DEFAULT', mode='TEST', test_data=data) == {'CANCELLED'}
-    warnings.warn(UserWarning(f"Test is not fully implemented yet"))
+    warnings.warn(UserWarning("Test is not fully implemented yet"))
 
 
 @pytest.mark.usefixtures("clean_all_objects")
@@ -112,4 +112,4 @@ def test_generate_volume_sequence_telemac_3d_cuda():
     # TODO: when pyopenvdb installation is fixed, change 'CANCELLED' to 'FINISH' to run the test
     op = bpy.ops.nimphs.telemac_generate_volume_sequence
     assert op('EXEC_DEFAULT', mode='TEST', test_data=data) == {'CANCELLED'}
-    warnings.warn(UserWarning(f"Test is not fully implemented yet"))
+    warnings.warn(UserWarning("Test is not fully implemented yet"))


### PR DESCRIPTION
# Overview

This PR modifies how point data are exported in volume sequences.
Point data are now exported as-is in voxels.

Resolves #6

## Details

No more 'remap' operation before assigning values to voxels.
Indeed, this 'remap' operation can be done using the 'Map Range' node in the Shader Node editor.

Small example:
![Screenshot from 2022-08-31 15-06-42](https://user-images.githubusercontent.com/22941087/187685542-41108cd0-9b86-41da-b1d9-61d879f6444e.png)


